### PR TITLE
Update opentelemetry version, adapt to breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ path = "src/lib.rs"
 
 [dependencies]
 tracing = "0.1"
-opentelemetry = { version = "0.26" }
-opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"] }
-opentelemetry-semantic-conventions = { version = "0.26" }
+opentelemetry = { version = "0.27" }
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
+opentelemetry-semantic-conventions = { version = "0.27" }
 gcloud-sdk = { version = "0.25", features = ["google-devtools-cloudtrace-v2"], default-features = false }
 rvstruct = "0.3"
 rsb_derive = "0.5"
@@ -40,8 +40,8 @@ tls-webpki-roots = ["gcloud-sdk/tls-webpki-roots"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-opentelemetry = { version = "0.26" }
+opentelemetry = { version = "0.27" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter","registry"] }
-tracing-opentelemetry = { version = "0.27" }
+tracing-opentelemetry = { version = "0.28" }
 cargo-husky = { version = "1.5", default-features = false, features = ["run-for-all", "prepush-hook", "run-cargo-fmt"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 use gcloud_sdk::error::Error;
-use opentelemetry::ExportError;
+use opentelemetry::trace::ExportError;
 use rsb_derive::*;
 
 pub type BoxedError = Box<dyn std::error::Error + Send + Sync>;

--- a/src/google_trace_exporter_client.rs
+++ b/src/google_trace_exporter_client.rs
@@ -142,6 +142,10 @@ impl GcpCloudTraceExporterClient {
                         MAX_STR_LEN,
                     ))
                 }
+                _ => gcp_attribute_value::Value::StringValue(Self::truncatable_string(
+                    "unknown_value",
+                    MAX_STR_LEN,
+                )),
             }),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,11 @@ pub type TraceExportResult<E> = Result<E, crate::errors::GcloudTraceError>;
 mod google_trace_exporter_client;
 mod span_exporter;
 
-use std::ops::Deref;
-
 use opentelemetry::trace::TracerProvider;
+use opentelemetry::InstrumentationScope;
 use opentelemetry_sdk::Resource;
 pub use span_exporter::GcpCloudTraceExporter;
+use std::ops::Deref;
 
 use rsb_derive::*;
 
@@ -107,11 +107,12 @@ impl GcpCloudTraceExporterBuilder {
                 .build()
         };
 
-        let tracer = provider
-            .tracer_builder("opentelemetry-gcloud")
+        let scope = InstrumentationScope::builder("opentelemetry-gcloud")
             .with_version(env!("CARGO_PKG_VERSION"))
             .with_schema_url("https://opentelemetry.io/schemas/1.23.0")
             .build();
+
+        let tracer = provider.tracer_with_scope(scope);
 
         let _ = opentelemetry::global::set_tracer_provider(provider);
         Ok(tracer)


### PR DESCRIPTION
Updated the opentelemetry, opentelemetry_sdk, opentelemetry-semantic-conventions from 0.26 to 0.27 and tracing-opentelemtry from 0.27 to 0.28.

I had to adapt certain part of the code to handle breaking changes, most notable:
- the opentelemetry::Value enum is now marked as non_exhaustive forcing a catch all match arm
- the TraceProvider::tracer_builder method has been removed, I use instead the tracer_with_scope