### PR TITLE
Changed TracerProvider configuration to use the TracerProvider::Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ opentelemetry-gcloud-trace = "*"
 
 ## Configuration
 
-You can specify trace configuration using `with_trace_config`:
+You can specify trace configuration using `with_tracer_provider_builder`:
 
 ```rust
-   GcpCloudTraceExporterBuilder::new(google_project_id).with_trace_config(
-      trace::config()
+   GcpCloudTraceExporterBuilder::new(google_project_id).with_tracer_provider_builder(
+       TracerProvider::builder()
          .with_sampler(Sampler::AlwaysOn)
          .with_id_generator(RandomIdGenerator::default())
    )


### PR DESCRIPTION
In opentelemetry-sdk version 0.27.1 there is a deprecation warning:

> DEPRECATED:
> 
>     trace::Config methods are moving onto TracerProvider Builder to be consistent with other signals. See https://github.com/open-telemetry/opentelemetry-rust/pull/2303 for migration guide.
> trace::Config is scheduled to be removed from public API in v0.28.0. example:
> 
>     // old
>     let tracer_provider: TracerProvider = TracerProvider::builder()
>         .with_config(Config::default().with_resource(Resource::empty()))
>         .build();
> 
>     // new
>     let tracer_provider: TracerProvider = TracerProvider::builder()
>         .with_resource(Resource::empty())
>         .build();

This is my attempt to reflect the changes in the GcpCloudTraceExporterBuilder builder.
The GcpCloudTraceExporterBuilder  does not take a config element like before but the tracer provider builder.
We can no longer extract from the config the resources and I found no way to extract them from the builder to pass them to the GcpCloudTraceExporter.
The only option I see is to do use a with_resource to keep the same logic
```rust 
let resources = Resource::new(vec![KeyValue::new("service.name", "my-service")]);
GcpCloudTraceExporterBuilder::new(google_project_id).with_tracer_provider_builder(
       TracerProvider::builder()
          .with_sampler(Sampler::AlwaysOn)
          .with_id_generator(RandomIdGenerator::default(
          .with_resource(resource.clone()),
    )
    .with_resource(resource)
    .await?;
```
 🤔 I'm not a big fan of the repetition of .with_resource on two different constructor, but I don't see another way