### PR TITLE
fix(deps): update rust crate gcloud-sdk to 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1"
 opentelemetry = { version = "0.32" }
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "experimental_trace_batch_span_processor_with_async_runtime"] }
 opentelemetry-semantic-conventions = { version = "0.32" }
-gcloud-sdk = { version = "0.30", features = ["google-devtools-cloudtrace-v2"], default-features = false }
+gcloud-sdk = { version = "0.31", features = ["google-devtools-cloudtrace-v2"], default-features = false }
 rvstruct = "0.3"
 rsb_derive = "0.5"
 tokio-stream = "0.1"


### PR DESCRIPTION
Updates gcloud-sdk to 0.31. No source changes are needed: the exporter converts std::time::SystemTime through prost_types::Timestamp and does not use the SDK types affected by its chrono to jiff migration.